### PR TITLE
Removed a confusing 'from' from the readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will also need to install [octokit](https://github.com/octokit/octokit.rb).
 
 
 
-#####Importing issues from into GitHub using csv_issues_to_github.rb
+#####Importing issues into GitHub using csv_issues_to_github.rb
 
 `./csv_issues_to_github.rb` to import issues *into* GitHub from a CSV
 


### PR DESCRIPTION
When reading the readme initially I got very confused in the section on importing issues into Github as the line implies (if you read it quickly) that this section is about importing from Github (exporting).

Removing the word from would solve this issue for other people in the future.