### PR TITLE
Add Issue Close Date to CSV Export

### DIFF
--- a/github_issues_to_csv.rb
+++ b/github_issues_to_csv.rb
@@ -9,37 +9,37 @@ require 'date'
 # Comment out this section (from here down to where the end is marked) if you want to use this interactively
 
 puts "Username:"
-USERNAME = gets.chomp  
+USERNAME = gets.chomp
 if USERNAME == ""
 	abort("You need to supply a username. Thank you, come again.")
 end
 
 puts "Password:"
-PASSWORD = gets.chomp  
+PASSWORD = gets.chomp
 if PASSWORD == ""
 	abort("You need to supply a password. Thank you, come again.")
 end
 
 puts "Name of the file you want to create? (.csv will be appended automatically)"
-OUTPUT_FILE = gets.chomp  
+OUTPUT_FILE = gets.chomp
 if OUTPUT_FILE == ""
 	abort("You need to supply a CSV file. Thank you, come again.")
 end
 
 puts "Organization?"
-ORG = gets.chomp  
+ORG = gets.chomp
 if ORG == ""
 	abort("You need to supply an organization. Thank you, come again.")
 end
 
 puts "Repository?"
-REPO = gets.chomp  
+REPO = gets.chomp
 if REPO == ""
 	abort("You need to supply a repository. Thank you, come again.")
 end
 
 puts "Do you want just one Milestone? If so, enter it now. Leave this blank to get the entire repo."
-TARGET_MILESTONE = gets.chomp  
+TARGET_MILESTONE = gets.chomp
 
 # END INTERACTIVE SECTION
 
@@ -50,7 +50,7 @@ TARGET_MILESTONE = gets.chomp
 =begin
 OUTPUT_FILE = ""
 USERNAME = ""   # Put your GitHub username inside the quotes
-PASSWORD = ""   # Put your GitHub password inside the quotes 
+PASSWORD = ""   # Put your GitHub password inside the quotes
 ORG = ""        # Put your organization (or username if you have no org) name here
 REPO = ""       # Put the repository name here
 # Want to only get a single milestone? Put the milestone name in here:
@@ -60,11 +60,11 @@ TARGET_MILESTONE="" # keep this equal to "" if you want all milestones
 
 # Your local timezone offset to convert times
 TIMEZONE_OFFSET="-4"
- 
+
 client = Octokit::Client.new(:login => USERNAME, :password => PASSWORD)
- 
+
 csv = CSV.new(File.open(File.dirname(__FILE__) + "/" + OUTPUT_FILE + ".csv", 'w'))
- 
+
 puts "Initialising CSV file..."
 #CSV Headers
 header = [
@@ -73,6 +73,7 @@ header = [
   "Description",
   "Date created",
   "Date modified",
+	"Date closed",
   "Labels",
   "Milestone",
   "Status",
@@ -81,7 +82,7 @@ header = [
 ]
 
 csv << header
- 
+
 puts "Getting issues from Github..."
 temp_issues = []
 issues = []
@@ -98,7 +99,7 @@ begin
 	temp_issues = client.list_issues("#{ORG}/#{REPO}", :state => "open", :page => page)
 	issues = issues + temp_issues;
 end while not temp_issues.empty?
- 
+
 puts "Processing #{issues.size} issues..."
 issues.each do |issue|
 
@@ -106,21 +107,26 @@ issues.each do |issue|
 	label = issue['labels'] || "None"
 	if (label != "None")
 		label.each do |item|
-    		labels += item['name'] + " " 
-    	end	
+    		labels += item['name'] + " "
+    	end
 	end
 
 	assignee = ""
 	assignee = issue['assignee'] || "None"
 	if (assignee != "None")
 		assignee = assignee['login']
-	end	
+	end
 
 	milestone = issue['milestone'] || "None"
 	if (milestone != "None")
 		milestone = milestone['title']
 	end
- 
+
+	closed_at = issue['closed_at'] || "None"
+	if( closed_at != "None")
+		closed_at = DateTime.parse(issue['closed_at'].to_s).new_offset(TIMEZONE_OFFSET).strftime("%d/%b/%y %l:%M %p")
+	end
+
 	if ((TARGET_MILESTONE == "") || (milestone == TARGET_MILESTONE))
     # Needs to match the header order above, date format are based on Jira default
     row = [
@@ -129,6 +135,7 @@ issues.each do |issue|
       issue['body'],
       DateTime.parse(issue['created_at'].to_s).new_offset(TIMEZONE_OFFSET).strftime("%d/%b/%y %l:%M %p"),
       DateTime.parse(issue['updated_at'].to_s).new_offset(TIMEZONE_OFFSET).strftime("%d/%b/%y %l:%M %p"),
+      closed_at,
       labels,
       milestone,
       issue['state'],


### PR DESCRIPTION
In order to create graphs of open vs. close rate over time, it's important to track issue close date.
